### PR TITLE
Close TBMChan when the session is closed

### DIFF
--- a/src/Network/JSONRPC/Interface.hs
+++ b/src/Network/JSONRPC/Interface.hs
@@ -326,7 +326,7 @@ runJSONRPCT ver ignore snk src f = do
     qs <- liftIO . atomically $ initSession ver ignore
     let inSnk  = sinkTBMChan (inCh qs)
         outSrc = sourceTBMChan (outCh qs)
-    withAsync (runConduit $ src .| decodeConduit ver .| inSnk) $ const $
+    withAsync ((runConduit $ src .| decodeConduit ver .| inSnk) >> liftIO (atomically $ closeTBMChan $ inCh qs)) $ const $
         withAsync (runConduit $ outSrc .| encodeConduit .| snk) $ \o ->
             withAsync (runReaderT processIncoming qs) $ const $ do
                 a <- runReaderT f qs


### PR DESCRIPTION
There is a bug in the library, wherein this codepath

https://github.com/jprupp/json-rpc/blob/45d8a75d050967391cb3908f0fa0e6d1812b21e7/src/Network/JSONRPC/Interface.hs#L121

is never reached, because when the `src` conduit finishes yielding results (as a result of the socket connection being terminated), `src .| decodeConduit ver .| inSnk` finishes without closing the `inCh qs` TMBChan, hence, the `readTBMChan` here

https://github.com/jprupp/json-rpc/blob/45d8a75d050967391cb3908f0fa0e6d1812b21e7/src/Network/JSONRPC/Interface.hs#L116-L121

block indefinitely.